### PR TITLE
Enable asyncDataFetching

### DIFF
--- a/Source/WallController.swift
+++ b/Source/WallController.swift
@@ -14,7 +14,7 @@ public class WallController: UIViewController {
     frame.origin.y += 20
 
     let collectionView = ASCollectionView(frame: CGRectZero,
-      collectionViewLayout: self.flowLayout, asyncDataFetching: false)
+      collectionViewLayout: self.flowLayout, asyncDataFetching: true)
     collectionView.alwaysBounceVertical = true
     collectionView.autoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth
     collectionView.backgroundColor = .whiteColor()
@@ -57,28 +57,17 @@ public class WallController: UIViewController {
   }
 }
 
-extension WallController {
-  public func scrollViewDidScroll(scrollView: UIScrollView) {
-    if delegate != nil && scrollingState != .Loading {
-      let contentHeight = scrollView.contentSize.height
-      let offsetTreshold = contentHeight - scrollView.bounds.size.height
-
-      if scrollView.contentOffset.y > offsetTreshold && scrollingState == .Stopped {
-        println("loading...")
-        scrollingState = .Loading
-        if let delegate = self.delegate,
-          delegateMethod = delegate.wallDidScrollToEnd {
-            delegateMethod() {
-              self.scrollingState = .Stopped
-            }
-        }
-      } else if scrollView.contentOffset.y < offsetTreshold && scrollingState != .Stopped {
-        println("stopped")
-        scrollingState = .Stopped
-      }
-    }
-  }
-}
-
 extension WallController: ASCollectionViewDelegate {
+
+  public func collectionView(collectionView: ASCollectionView!,
+    willBeginBatchFetchWithContext context: ASBatchContext!) {
+      scrollingState = .Loading
+      if let delegate = delegate,
+        delegateMethod = delegate.wallDidScrollToEnd {
+          delegateMethod() {
+            context.completeBatchFetching(true)
+            self.scrollingState = .Stopped
+          }
+      }
+  }
 }


### PR DESCRIPTION
As I see from documentation for `ASCollectionView` initialiser there are some advantages of using `asyncDataFetching`. So I think it makes a sense to use it in combination with `collectionView(collectionView: ASCollectionView!, willBeginBatchFetchWithContext context: ASBatchContext!)`. It works a bit different comparing with your solution (starts fetching earlier), so please check how it works now in Demo.  