### PR TITLE
Add attachment grid types

### DIFF
--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -139,8 +139,13 @@ public class Config {
       }
 
       public struct Attachments {
+        public enum GridType {
+          case Regular, FullWidth, SingleFullWidth
+        }
+
         public var ratio: CGFloat = 3 / 2
         public var padding: CGFloat = 10
+        public var gridType = GridType.Regular
         public var counter = Counter()
 
         public struct Counter {

--- a/Source/Nodes/PostCellNode.swift
+++ b/Source/Nodes/PostCellNode.swift
@@ -59,10 +59,17 @@ public class PostCellNode: ASCellNode {
       }
 
       if let attachments = post.attachments where attachments.count > 0 {
+        var gridWidth = contentWidth
+        if postConfig.attachments.gridType == .FullWidth {
+          gridWidth = width
+        } else if postConfig.attachments.gridType == .SingleFullWidth {
+          gridWidth = attachments.count > 1 ? contentWidth : width
+        }
+
         attachmentGridNode = AttachmentGridNode(
           config: config,
           attachments: attachments,
-          width: contentWidth)
+          width: gridWidth)
         attachmentGridNode!.userInteractionEnabled = true
 
         addSubnode(attachmentGridNode)


### PR DESCRIPTION
New grid types for attachments inside the post cell:
1. `Regular` - with left and right padding.
2.  `FullWidth` - without paddings
3. `SingleFullWidth` - no padding if there is only one image/video, padding for more than one attachment.