### PR TITLE
Refactor/model optionals

### DIFF
--- a/Example/App.Net/App.Net.xcodeproj/project.pbxproj
+++ b/Example/App.Net/App.Net.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 		BD8E439B1AEBD9EB00BC0631 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0640;
 				TargetAttributes = {
 					BD8E43A41AEBDA0F00BC0631 = {
 						CreatedOnToolsVersion = 6.3.1;
@@ -241,6 +241,7 @@
 		BD8E439F1AEBD9EB00BC0631 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};

--- a/Example/App.Net/App.Net/Post.swift
+++ b/Example/App.Net/App.Net/Post.swift
@@ -4,8 +4,8 @@ import Sugar
 class Post: Postable {
 
   var id = 0
-  var publishDate: NSDate?
-  var text: String?
+  var publishDate = NSDate()
+  var text = ""
   var liked = false
   var seen = false
   var likeCount = 0
@@ -18,7 +18,7 @@ class Post: Postable {
   var attachments = [Attachable]()
   var comments = [Postable]()
 
-  init(text: String? = nil, date: NSDate? = nil) {
+  init(text: String = "", date: NSDate = NSDate()) {
     self.text = text
     self.publishDate = date
   }

--- a/Example/InfiniteScroll/InfiniteScroll/DetailViewController.swift
+++ b/Example/InfiniteScroll/InfiniteScroll/DetailViewController.swift
@@ -14,13 +14,7 @@ class DetailViewController: WallController {
     collectionView.backgroundColor = config.wall.comment.backgroundColor
     config.wall.thumbnailForAttachment = {
       (attachment: Attachable, size: CGSize) -> URLStringConvertible? in
-      var string: URLStringConvertible?
-
-      if let thumbnail = attachment.thumbnail {
-        string = String(format: thumbnail.string, Int(size.width), Int(size.height))
-      }
-
-      return string
+      return String(format: attachment.source.string, Int(size.width), Int(size.height))
     }
 
     if let comments = post?.comments {

--- a/Example/InfiniteScroll/InfiniteScroll/Models.swift
+++ b/Example/InfiniteScroll/InfiniteScroll/Models.swift
@@ -3,10 +3,10 @@ import Sugar
 
 class Image: Displayable {
 
-  var source: URLStringConvertible?
+  var source: URLStringConvertible
   var thumbnail: URLStringConvertible?
 
-  init(_ source: URLStringConvertible?, _ thumbnail: URLStringConvertible? = nil) {
+  init(_ source: URLStringConvertible, _ thumbnail: URLStringConvertible? = nil) {
     self.source = source
     self.thumbnail = thumbnail
   }
@@ -14,10 +14,10 @@ class Image: Displayable {
 
 class Group: Groupable {
 
-  var name: String?
+  var name: String
   var image: Displayable?
 
-  init(name: String? = nil, image: Image? = nil) {
+  init(name: String, image: Image? = nil) {
     self.name = name
     self.image = image
   }
@@ -25,10 +25,10 @@ class Group: Groupable {
 
 class User: Profileable {
 
-  var fullName: String?
+  var fullName: String
   var avatar: Displayable?
 
-  init(fullName: String? = nil, avatar: Displayable? = nil) {
+  init(fullName: String, avatar: Displayable? = nil) {
     self.fullName = fullName
     self.avatar = avatar
   }
@@ -37,8 +37,8 @@ class User: Profileable {
 class Post: Postable {
 
   var id = 0
-  var publishDate: NSDate?
-  var text: String?
+  var publishDate = NSDate()
+  var text = ""
   var liked = false
   var seen = false
   var likeCount = 0
@@ -51,7 +51,7 @@ class Post: Postable {
   var attachments = [Attachable]()
   var comments = [Postable]()
 
-  init(text: String? = nil, date: NSDate? = nil, author: Profileable? = nil,
+  init(text: String = "", date: NSDate = NSDate(), author: Profileable? = nil,
     attachments: [Attachable] = []) {
       self.text = text
       self.publishDate = date

--- a/Example/InfiniteScroll/InfiniteScroll/ViewController.swift
+++ b/Example/InfiniteScroll/InfiniteScroll/ViewController.swift
@@ -15,13 +15,7 @@ class ViewController: WallController {
     config.wall.post.text.textAttributes[NSForegroundColorAttributeName] = UIColor.darkTextColor()
     config.wall.thumbnailForAttachment = {
       (attachment: Attachable, size: CGSize) -> URLStringConvertible? in
-      var string: URLStringConvertible?
-      
-      if let thumbnail = attachment.thumbnail {
-        string = String(format: thumbnail.string, Int(size.width), Int(size.height))
-      }
-
-      return string
+      return String(format: attachment.source.string, Int(size.width), Int(size.height))
     }
 
     self.tapDelegate = self

--- a/Source/Models/Attachable.swift
+++ b/Source/Models/Attachable.swift
@@ -3,7 +3,7 @@ import Sugar
 public protocol Attachable {
 
   var thumbnail: URLStringConvertible? { get }
-  var source: URLStringConvertible? { get }
+  var source: URLStringConvertible { get }
 }
 
 public protocol Displayable: Attachable { }

--- a/Source/Models/Coordinate.swift
+++ b/Source/Models/Coordinate.swift
@@ -1,9 +1,9 @@
 public struct Coordinate {
 
-  public var latitude: Double?
-  public var longitude: Double?
+  public var latitude: Double
+  public var longitude: Double
 
-  public init(latitude: Double? = nil, longitude: Double? = nil) {
+  public init(latitude: Double, longitude: Double) {
     self.latitude = latitude
     self.longitude = longitude
   }

--- a/Source/Models/Groupable.swift
+++ b/Source/Models/Groupable.swift
@@ -1,5 +1,5 @@
 public protocol Groupable {
 
-  var name: String? { get }
+  var name: String { get }
   var image: Displayable? { get }
 }

--- a/Source/Models/Location.swift
+++ b/Source/Models/Location.swift
@@ -1,9 +1,9 @@
 public struct Location {
 
-  public var name: String?
+  public var name: String
   public var coordinate: Coordinate?
 
-  public init(name: String? = nil, coordinate: Coordinate? = nil) {
+  public init(name: String, coordinate: Coordinate? = nil) {
     self.name = name
     self.coordinate = coordinate
   }

--- a/Source/Models/Post.swift
+++ b/Source/Models/Post.swift
@@ -3,8 +3,8 @@ import Foundation
 public protocol Postable {
 
   var id: Int { get }
-  var publishDate: NSDate? { get }
-  var text: String? { get }
+  var publishDate: NSDate { get }
+  var text: String { get }
   var liked: Bool { get }
   var seen: Bool { get }
   var likeCount: Int { get }

--- a/Source/Models/User.swift
+++ b/Source/Models/User.swift
@@ -1,5 +1,5 @@
 public protocol Profileable {
 
-  var fullName: String? { get }
+  var fullName: String { get }
   var avatar: Displayable? { get }
 }

--- a/Source/Nodes/PostCellNode.swift
+++ b/Source/Nodes/PostCellNode.swift
@@ -60,10 +60,10 @@ public class PostCellNode: ASCellNode {
         addSubnode(attachmentGridNode)
       }
 
-      if let text = post.text {
+      if !post.text.isEmpty {
         textNode = ASTextNode()
         textNode!.attributedString = NSAttributedString(
-          string: text,
+          string: post.text,
           attributes: config.wall.post.text.textAttributes)
         textNode!.userInteractionEnabled = true
 

--- a/Source/Nodes/PostHeaderNode.swift
+++ b/Source/Nodes/PostHeaderNode.swift
@@ -6,7 +6,7 @@ public class PostHeaderNode: ASDisplayNode {
   public let config: Config
   public let width: CGFloat
 
-  public var authorNameNode: ASTextNode?
+  public var authorNameNode = ASTextNode()
   public var authorAvatarNode: ASImageNode?
   public var groupNode: ASTextNode?
   public var groupDivider: ASTextNode?
@@ -22,6 +22,10 @@ public class PostHeaderNode: ASDisplayNode {
     return config.wall.post.header
   }
 
+  private var secondRowY: CGFloat {
+    return height / 2 + headerConfig.author.verticalPadding
+  }
+
   // MARK: - Initialization
 
   public init(config: Config, post: Postable, width: CGFloat) {
@@ -32,15 +36,12 @@ public class PostHeaderNode: ASDisplayNode {
 
     if headerConfig.author.enabled {
       if let author = post.author {
-        if let name = author.fullName {
-          authorNameNode = ASTextNode()
-          authorNameNode!.attributedString = NSAttributedString(
-            string: name,
-            attributes: headerConfig.author.textAttributes)
-          authorNameNode!.userInteractionEnabled = true
+        authorNameNode.attributedString = NSAttributedString(
+          string: author.fullName,
+          attributes: headerConfig.author.textAttributes)
+        authorNameNode.userInteractionEnabled = true
 
-          addSubnode(authorNameNode)
-        }
+        addSubnode(authorNameNode)
 
         if headerConfig.author.avatar.enabled {
           if let avatar = author.avatar {
@@ -71,7 +72,7 @@ public class PostHeaderNode: ASDisplayNode {
       if let group = post.group {
         groupNode = ASTextNode()
         groupNode!.attributedString = NSAttributedString(
-          string: group.name!,
+          string: group.name,
           attributes: headerConfig.group.textAttributes)
         groupNode!.userInteractionEnabled = true
 
@@ -91,15 +92,13 @@ public class PostHeaderNode: ASDisplayNode {
 
     if headerConfig.location.enabled {
       if let location = post.location {
-        if let name = location.name {
-          locationNode = ASTextNode()
-          locationNode!.attributedString = NSAttributedString(
-            string: name,
-            attributes: headerConfig.location.textAttributes)
-          locationNode!.userInteractionEnabled = true
+        locationNode = ASTextNode()
+        locationNode!.attributedString = NSAttributedString(
+          string: location.name,
+          attributes: headerConfig.location.textAttributes)
+        locationNode!.userInteractionEnabled = true
 
-          addSubnode(locationNode)
-        }
+        addSubnode(locationNode)
 
         if headerConfig.location.icon.enabled {
           locationIconNode = ASImageNode()
@@ -112,15 +111,13 @@ public class PostHeaderNode: ASDisplayNode {
     }
 
     if headerConfig.date.enabled {
-      if let date = post.publishDate {
-        dateNode = ASTextNode()
-        dateNode!.attributedString = NSAttributedString(
-          string: config.wall.stringFromPostDate(date: date),
-          attributes: headerConfig.date.textAttributes)
-        dateNode!.userInteractionEnabled = true
+      dateNode = ASTextNode()
+      dateNode!.attributedString = NSAttributedString(
+        string: config.wall.stringFromPostDate(date: post.publishDate),
+        attributes: headerConfig.date.textAttributes)
+      dateNode!.userInteractionEnabled = true
 
-        addSubnode(dateNode)
-      }
+      addSubnode(dateNode)
     }
   }
 
@@ -147,17 +144,16 @@ public class PostHeaderNode: ASDisplayNode {
     }
 
     var authorNameX = x
-    if let authorNameNode = authorNameNode {
-      let size = authorNameNode.measure(
-        CGSize(
-          width: CGFloat(FLT_MAX),
-          height: height))
 
-      authorNameNode.frame = CGRect(
-        origin: CGPoint(x: x, y: firstRowY(size.height)),
-        size: size)
-      x += size.width + authorConfig.horizontalPadding
-    }
+    let size = authorNameNode.measure(
+      CGSize(
+        width: CGFloat(FLT_MAX),
+        height: height))
+
+    authorNameNode.frame = CGRect(
+      origin: CGPoint(x: x, y: firstRowY(size.height)),
+      size: size)
+    x += size.width + authorConfig.horizontalPadding
 
     if let dateNode = dateNode {
       let size = dateNode.measure(
@@ -211,7 +207,7 @@ public class PostHeaderNode: ASDisplayNode {
           width: CGFloat(FLT_MAX),
           height: height))
 
-      let rowY = secondRowY(size.height)
+      let rowY = secondRowY
       if let locationIconNode = locationIconNode {
         let iconConfig = headerConfig.location.icon
 
@@ -230,19 +226,13 @@ public class PostHeaderNode: ASDisplayNode {
 
   // MARK: - Private Methods
 
-  func centerY(height: CGFloat) -> CGFloat {
+  private func centerY(height: CGFloat) -> CGFloat {
     return (self.height - height) / 2
   }
 
-  func firstRowY(height: CGFloat) -> CGFloat {
+  private func firstRowY(height: CGFloat) -> CGFloat {
     return self.locationNode != nil ?
       self.height / 2 - height - headerConfig.author.verticalPadding :
-      centerY(height)
-  }
-
-  func secondRowY(height: CGFloat) -> CGFloat {
-    return self.authorNameNode != nil ?
-      self.height / 2 + headerConfig.author.verticalPadding :
       centerY(height)
   }
 }

--- a/Tests/WallTests/Nodes/PostFooterNodeSpec.swift
+++ b/Tests/WallTests/Nodes/PostFooterNodeSpec.swift
@@ -58,7 +58,7 @@ class PostFooterNodeSpec: QuickSpec {
           }
 
           it("adds the node with the number of views") {
-            let string = "\(footerConfig.seen.text) \(post.seen)"
+            let string = "\(footerConfig.seen.text) \(post.seenCount)"
 
             expect(node.seenNode).notTo(beNil())
             expect(node.seenNode!.attributedString).to(equal(

--- a/Tests/WallTests/SpecHelper.swift
+++ b/Tests/WallTests/SpecHelper.swift
@@ -3,10 +3,10 @@ import Sugar
 
 class Image: Displayable {
 
-  var source: URLStringConvertible?
+  var source: URLStringConvertible
   var thumbnail: URLStringConvertible?
 
-  init(_ source: URLStringConvertible?, _ thumbnail: URLStringConvertible? = nil) {
+  init(_ source: URLStringConvertible, _ thumbnail: URLStringConvertible? = nil) {
     self.source = source
     self.thumbnail = thumbnail
   }
@@ -15,10 +15,10 @@ class Image: Displayable {
 
 class Group: Groupable {
 
-  var name: String?
+  var name: String
   var image: Displayable?
 
-  init(name: String? = nil, image: Image? = nil) {
+  init(name: String, image: Image? = nil) {
     self.name = name
     self.image = image
   }
@@ -26,10 +26,10 @@ class Group: Groupable {
 
 class User: Profileable {
 
-  var fullName: String?
+  var fullName: String
   var avatar: Displayable?
 
-  init(fullName: String? = nil, avatar: Displayable? = nil) {
+  init(fullName: String, avatar: Displayable? = nil) {
     self.fullName = fullName
     self.avatar = avatar
   }
@@ -38,8 +38,8 @@ class User: Profileable {
 class Post: Postable {
 
   var id = 0
-  var publishDate: NSDate?
-  var text: String?
+  var publishDate = NSDate()
+  var text = ""
   var liked = false
   var seen = false
   var likeCount = 0
@@ -52,7 +52,7 @@ class Post: Postable {
   var attachments = [Attachable]()
   var comments = [Postable]()
 
-  init(text: String? = nil, date: NSDate? = nil, author: Profileable? = nil,
+  init(text: String = "", date: NSDate, author: Profileable? = nil,
     attachments: [Attachable] = []) {
       self.text = text
       self.publishDate = date


### PR DESCRIPTION
@zenangst @RamonGilabert 
`Realm` dictates some rules :smiley:, it supports optionals only for relation objects. And I think it makes sense to have such properties as `text`, `publishDate`, `fullName` as non-optionals, if someone really needs it's possible to set empty values or hide views that are not used.