### PR TITLE
Feature/custom cell

### DIFF
--- a/Example/App.Net/Podfile.lock
+++ b/Example/App.Net/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AsyncDisplayKit (1.2.2):
-    - AsyncDisplayKit/ASDealloc2MainObject (= 1.2.2)
-  - AsyncDisplayKit/ASDealloc2MainObject (1.2.2)
+  - AsyncDisplayKit (1.2.3):
+    - AsyncDisplayKit/ASDealloc2MainObject (= 1.2.3)
+  - AsyncDisplayKit/ASDealloc2MainObject (1.2.3)
   - DATAFilter (0.8.1):
     - DATAObjectIDs
   - DATAObjectIDs (0.5.0)
@@ -44,7 +44,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  AsyncDisplayKit: 6b943f45844558fde1d82468820dbefcc77c7271
+  AsyncDisplayKit: 5c8f38225f7478e39c48196cec0dd0d2ac3455ed
   DATAFilter: 3f89692f7c52dd3c3973287ee8c9bb2c0e76d344
   DATAObjectIDs: 472eae6d8d6b57109b973c837ec3dd5e78016ab6
   DATAStack: de58e278b0487ff5a508d158cc74dd8b5e302389
@@ -58,4 +58,4 @@ SPEC CHECKSUMS:
   Sync: 984b6dfb10cf8a7df97e7bfe22e1babb403fd4c7
   Wall: bd9e0a46f4826fbbd5692c68a7cc3a5adc1ae834
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Example/InfiniteScroll/Podfile.lock
+++ b/Example/InfiniteScroll/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AsyncDisplayKit (1.2.2):
-    - AsyncDisplayKit/ASDealloc2MainObject (= 1.2.2)
-  - AsyncDisplayKit/ASDealloc2MainObject (1.2.2)
+  - AsyncDisplayKit (1.2.3):
+    - AsyncDisplayKit/ASDealloc2MainObject (= 1.2.3)
+  - AsyncDisplayKit/ASDealloc2MainObject (1.2.3)
   - Faker (0.1.0):
     - SwiftyJSON (~> 2.2.0)
   - HanekeSwift (0.9.1)
@@ -34,11 +34,11 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  AsyncDisplayKit: 6b943f45844558fde1d82468820dbefcc77c7271
+  AsyncDisplayKit: 5c8f38225f7478e39c48196cec0dd0d2ac3455ed
   Faker: ec2361307c261ae4b26c8da20b127d416faf0ebd
   HanekeSwift: 50d37bfbc4432edc649167e538c259feccb4a2bb
   Sugar: d33f2a3ae10e40c14eb49a2e859f12e82e614817
   SwiftyJSON: 0b3e6c07af17ff745e77e8e9984097b55c956e5c
   Wall: bd9e0a46f4826fbbd5692c68a7cc3a5adc1ae834
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -10,7 +10,7 @@ public class Config {
   public init() {}
 
   public struct Cache {
-    
+
     public struct Thumbnails {
       public static var format = "wall-thumbnails"
       public static var storage: Haneke.Cache<UIImage> {
@@ -45,7 +45,7 @@ public class Config {
     public var comment = Comment()
 
     public struct Post {
-      public var cellClass: PostableCellNode.Type = PostCellNode.self
+      public var CellClass: WallCellNode.Type = PostCellNode.self
 
       public var horizontalPadding: CGFloat = 10
       public var verticalPadding: CGFloat = 10
@@ -231,7 +231,7 @@ public class Config {
     }
 
     public struct Comment {
-      public var cellClass: PostableCellNode.Type = CommentCellNode.self
+      public var CellClass: WallCellNode.Type = CommentCellNode.self
 
       public var backgroundColor =  UIColor(red:0.969, green:0.973, blue:0.976, alpha: 1)
       public var divider = Divider()

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -10,6 +10,7 @@ public class Config {
   public init() {}
 
   public struct Cache {
+    
     public struct Thumbnails {
       public static var format = "wall-thumbnails"
       public static var storage: Haneke.Cache<UIImage> {
@@ -44,6 +45,8 @@ public class Config {
     public var comment = Comment()
 
     public struct Post {
+      public var cellClass: PostableCellNode.Type = PostCellNode.self
+
       public var horizontalPadding: CGFloat = 10
       public var verticalPadding: CGFloat = 10
       public var backgroundColor = UIColor.whiteColor()
@@ -228,6 +231,8 @@ public class Config {
     }
 
     public struct Comment {
+      public var cellClass: PostableCellNode.Type = CommentCellNode.self
+
       public var backgroundColor =  UIColor(red:0.969, green:0.973, blue:0.976, alpha: 1)
       public var divider = Divider()
 

--- a/Source/Nodes/CommentCellNode.swift
+++ b/Source/Nodes/CommentCellNode.swift
@@ -9,7 +9,7 @@ public class CommentCellNode: PostCellNode {
 
   // MARK: - Initialization
 
-  public override init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
+  public required init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
     super.init(post: post, index: index, width: width, delegate: delegate)
 
     if let config = config {

--- a/Source/Nodes/PostCellNode.swift
+++ b/Source/Nodes/PostCellNode.swift
@@ -5,14 +5,26 @@ public protocol PostableCellNode {
   init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate?)
 }
 
-public class PostCellNode: ASCellNode, PostableCellNode {
+public class WallCellNode: ASCellNode, PostableCellNode {
 
   public var post: Post
   public let index: Int
   public let width: CGFloat
   public var config: Config?
-
   weak public var delegate: PostCellNodeDelegate?
+
+  public required init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
+    self.post = post
+    self.index = index
+    self.width = width
+    self.delegate = delegate
+    self.config = self.delegate?.config
+
+    super.init()
+  }
+}
+
+public class PostCellNode: WallCellNode {
 
   public var headerNode: PostHeaderNode?
   public var attachmentGridNode: AttachmentGridNode?
@@ -29,16 +41,14 @@ public class PostCellNode: ASCellNode, PostableCellNode {
     return contentWidth
   }
 
+  public var cellNode: ASCellNode {
+    return self
+  }
+
   // MARK: - Initialization
 
   public required init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
-    self.post = post
-    self.index = index
-    self.width = width
-    self.delegate = delegate
-    self.config = self.delegate?.config
-
-    super.init()
+    super.init(post: post, index: index, width: width, delegate: delegate)
 
     if let config = config {
       let postConfig = config.wall.post

--- a/Source/Nodes/PostCellNode.swift
+++ b/Source/Nodes/PostCellNode.swift
@@ -1,7 +1,11 @@
 import UIKit
 import AsyncDisplayKit
 
-public class PostCellNode: ASCellNode {
+public protocol PostableCellNode {
+  init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate?)
+}
+
+public class PostCellNode: ASCellNode, PostableCellNode {
 
   public var post: Post
   public let index: Int
@@ -27,7 +31,7 @@ public class PostCellNode: ASCellNode {
 
   // MARK: - Initialization
 
-  public init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
+  public required init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
     self.post = post
     self.index = index
     self.width = width

--- a/Source/Nodes/PostCellNode.swift
+++ b/Source/Nodes/PostCellNode.swift
@@ -1,29 +1,6 @@
 import UIKit
 import AsyncDisplayKit
 
-public protocol PostableCellNode {
-  init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate?)
-}
-
-public class WallCellNode: ASCellNode, PostableCellNode {
-
-  public var post: Post
-  public let index: Int
-  public let width: CGFloat
-  public var config: Config?
-  weak public var delegate: PostCellNodeDelegate?
-
-  public required init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
-    self.post = post
-    self.index = index
-    self.width = width
-    self.delegate = delegate
-    self.config = self.delegate?.config
-
-    super.init()
-  }
-}
-
 public class PostCellNode: WallCellNode {
 
   public var headerNode: PostHeaderNode?
@@ -39,10 +16,6 @@ public class PostCellNode: WallCellNode {
       contentWidth = width - 2 * config.wall.post.horizontalPadding
     }
     return contentWidth
-  }
-
-  public var cellNode: ASCellNode {
-    return self
   }
 
   // MARK: - Initialization

--- a/Source/Nodes/WallCellNode.swift
+++ b/Source/Nodes/WallCellNode.swift
@@ -1,0 +1,25 @@
+import UIKit
+import AsyncDisplayKit
+
+public protocol PostableCellNode {
+  init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate?)
+}
+
+public class WallCellNode: ASCellNode, PostableCellNode {
+
+  public var post: Post
+  public let index: Int
+  public let width: CGFloat
+  public var config: Config?
+  weak public var delegate: PostCellNodeDelegate?
+
+  public required init(post: Post, index: Int, width: CGFloat, delegate: PostCellNodeDelegate? = nil) {
+    self.post = post
+    self.index = index
+    self.width = width
+    self.delegate = delegate
+    self.config = self.delegate?.config
+
+    super.init()
+  }
+}

--- a/Source/WallDataSource.swift
+++ b/Source/WallDataSource.swift
@@ -12,30 +12,20 @@ extension WallController: ASCollectionViewDataSource {
   }
 
   public func collectionView(collectionView: ASCollectionView!, nodeForItemAtIndexPath indexPath: NSIndexPath!) -> ASCellNode! {
-    let cellNode: ASCellNode
+    var CellClass = config.wall.post.CellClass
+    var index = indexPath.row
 
     if let post = post {
-      if indexPath.row > 0 {
-        cellNode = CommentCellNode(
-          post: posts[indexPath.row].wallModel,
-          index: indexPath.row - 1,
-          width: collectionView.frame.width,
-          delegate: self)
-      } else {
-        cellNode = PostCellNode(
-          post: posts[indexPath.row].wallModel,
-          index: 0,
-          width: collectionView.frame.width,
-          delegate: self)
-      }
-    } else {
-      cellNode = PostCellNode(
-        post: posts[indexPath.row].wallModel,
-        index: indexPath.row,
-        width: collectionView.frame.width,
-        delegate: self)
+      CellClass = indexPath.row > 0
+        ? config.wall.comment.CellClass
+        : config.wall.post.CellClass
+      index = indexPath.row > 0 ? indexPath.row - 1 : 0
     }
 
-    return cellNode
+    return CellClass(
+      post: self.posts[indexPath.row].wallModel,
+      index: index,
+      width: collectionView.frame.width,
+      delegate: self)
   }
 }

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -5,8 +5,8 @@ platform :ios, '8.0'
 use_frameworks!
 inhibit_all_warnings!
 
-pod 'AsyncDisplayKit', '1.2'
-pod 'HanekeSwift', '0.9.1'
+pod 'AsyncDisplayKit', '~> 1.2'
+pod 'HanekeSwift', '~> 0.9.1'
 pod 'Quick', '0.3.1'
 pod 'Nimble', '1.0.0-rc.1'
 pod 'Faker', git: 'https://github.com/vadymmarkov/Faker'

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AsyncDisplayKit (1.2):
-    - AsyncDisplayKit/ASDealloc2MainObject (= 1.2)
-  - AsyncDisplayKit/ASDealloc2MainObject (1.2)
+  - AsyncDisplayKit (1.2.3):
+    - AsyncDisplayKit/ASDealloc2MainObject (= 1.2.3)
+  - AsyncDisplayKit/ASDealloc2MainObject (1.2.3)
   - Faker (0.1.0):
     - SwiftyJSON (~> 2.2.0)
   - HanekeSwift (0.9.1)
@@ -11,9 +11,9 @@ PODS:
   - SwiftyJSON (2.2.0)
 
 DEPENDENCIES:
-  - AsyncDisplayKit (= 1.2)
+  - AsyncDisplayKit (~> 1.2)
   - Faker (from `https://github.com/vadymmarkov/Faker`)
-  - HanekeSwift (= 0.9.1)
+  - HanekeSwift (~> 0.9.1)
   - Nimble (= 1.0.0-rc.1)
   - Quick (= 0.3.1)
   - Sugar (from `https://github.com/hyperoslo/Sugar`)
@@ -33,7 +33,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/hyperoslo/Sugar
 
 SPEC CHECKSUMS:
-  AsyncDisplayKit: 32d5b9112b8c1b6644b54429e0cda4fbf6563781
+  AsyncDisplayKit: 5c8f38225f7478e39c48196cec0dd0d2ac3455ed
   Faker: ec2361307c261ae4b26c8da20b127d416faf0ebd
   HanekeSwift: 50d37bfbc4432edc649167e538c259feccb4a2bb
   Nimble: 23f1dbddf1706172c7d740430858e5dfa93d997a
@@ -41,4 +41,4 @@ SPEC CHECKSUMS:
   Sugar: d33f2a3ae10e40c14eb49a2e859f12e82e614817
   SwiftyJSON: 0b3e6c07af17ff745e77e8e9984097b55c956e5c
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BDF029EE1B2192C900C5027C /* Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF029ED1B2192C900C5027C /* Group.swift */; };
 		D52CF6C31B17090A002B4A5A /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52CF6C21B17090A002B4A5A /* Config.swift */; };
 		D52CF6C51B170B06002B4A5A /* WallDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52CF6C41B170B06002B4A5A /* WallDelegate.swift */; };
+		D535A2121B66DA95004A47B4 /* WallCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D535A2111B66DA95004A47B4 /* WallCellNode.swift */; };
 		D54B81D81B17147700FB0197 /* PostCellNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54B81D71B17147700FB0197 /* PostCellNode.swift */; };
 		D54B82061B175FCE00FB0197 /* Attachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54B82011B175FCE00FB0197 /* Attachable.swift */; };
 		D54B82081B175FCE00FB0197 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54B82031B175FCE00FB0197 /* Post.swift */; };
@@ -55,6 +56,7 @@
 		BDF029ED1B2192C900C5027C /* Group.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Group.swift; sourceTree = "<group>"; };
 		D52CF6C21B17090A002B4A5A /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D52CF6C41B170B06002B4A5A /* WallDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallDelegate.swift; sourceTree = "<group>"; };
+		D535A2111B66DA95004A47B4 /* WallCellNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WallCellNode.swift; sourceTree = "<group>"; };
 		D54B81D71B17147700FB0197 /* PostCellNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCellNode.swift; sourceTree = "<group>"; };
 		D54B82011B175FCE00FB0197 /* Attachable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attachable.swift; sourceTree = "<group>"; };
 		D54B82031B175FCE00FB0197 /* Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				D577C3391B1B83C1002D8C3B /* CounterNode.swift */,
 				D558ECA61B1B48C50072D719 /* CommentCellNode.swift */,
 				D5A787B81B27B25E00472D32 /* ControlNode.swift */,
+				D535A2111B66DA95004A47B4 /* WallCellNode.swift */,
 			);
 			path = Nodes;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				D558ECA51B1B48B00072D719 /* AttachmentGridNode.swift in Sources */,
 				D5D238281B581E7B008AED97 /* Image.swift in Sources */,
 				D52CF6C51B170B06002B4A5A /* WallDelegate.swift in Sources */,
+				D535A2121B66DA95004A47B4 /* WallCellNode.swift in Sources */,
 				D5F318E31B21B4EB00DE9899 /* PostFooterNodeSpec.swift in Sources */,
 				BDA23F571B218F3B00595C31 /* CoordinateSpec.swift in Sources */,
 				D5D2382A1B581EBA008AED97 /* Video.swift in Sources */,


### PR DESCRIPTION
@zenangst @RamonGilabert @richardoti 
Partially fixes https://github.com/hyperoslo/Wall/issues/60, we still have this `Config`, but meaw the cells are more customisable.

There are 2 things to improve customisation:
1) `PostableCellNode` protocol with required initialiser.
2) `WallCellNode` class that needs to be extended if you want to use your custom cell implementation instead of default `PostCellNode` (or of course, you can extend `PostCellNode`)

And the main magic is done in `Config`, if you want to use your custom cell:
```swift
config.wall.post.CellClass = MyAwesomePostCellNode.self
config.wall.comment.CellClass = MyAwesomeCommentCellNode.self
```