### PR TITLE
Kingfisher Image Cache

### DIFF
--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -2,8 +2,8 @@ import Foundation
 import AsyncDisplayKit
 import Kingfisher
 
-class ImageCache: NSObject, ASImageDownloaderProtocol {
-  func downloadImageWithURL(URL: NSURL!,
+public class ImageCache: NSObject, ASImageDownloaderProtocol {
+  public func downloadImageWithURL(URL: NSURL!,
     callbackQueue: dispatch_queue_t!,
     downloadProgressBlock: ((CGFloat) -> Void)!,
     completion: ((CGImage!, NSError!) -> Void)!) -> AnyObject! {
@@ -26,7 +26,7 @@ class ImageCache: NSObject, ASImageDownloaderProtocol {
       return task
   }
 
-  func cancelImageDownloadForIdentifier(downloadIdentifier: AnyObject!) {
+  public func cancelImageDownloadForIdentifier(downloadIdentifier: AnyObject!) {
     if let task = downloadIdentifier as? RetrieveImageTask {
       task.cancel()
     }

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -1,0 +1,34 @@
+import Foundation
+import AsyncDisplayKit
+import Kingfisher
+
+class ImageCache: NSObject, ASImageDownloaderProtocol {
+  func downloadImageWithURL(URL: NSURL!,
+    callbackQueue: dispatch_queue_t!,
+    downloadProgressBlock: ((CGFloat) -> Void)!,
+    completion: ((CGImage!, NSError!) -> Void)!) -> AnyObject! {
+
+      let manager = KingfisherManager.sharedManager
+
+      let task = manager.retrieveImageWithURL(URL,
+        options: .None,
+        progressBlock:
+        { receivedSize, totalSize in
+          dispatch_async(callbackQueue, {
+            downloadProgressBlock(CGFloat(receivedSize / totalSize))
+          })
+        })
+        { image, error, cacheType, imageURL in
+          dispatch_async(callbackQueue, {
+            completion(image!.CGImage, error)
+          })
+      }
+      return task
+  }
+
+  func cancelImageDownloadForIdentifier(downloadIdentifier: AnyObject!) {
+    if let task = downloadIdentifier as? RetrieveImageTask {
+      task.cancel()
+    }
+  }
+}

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -31,7 +31,6 @@ public class ImageCache: NSObject, ASImageDownloaderProtocol {
             })
           }
       }
-
       return task
   }
 

--- a/Source/ImageCache.swift
+++ b/Source/ImageCache.swift
@@ -14,15 +14,24 @@ public class ImageCache: NSObject, ASImageDownloaderProtocol {
         options: .None,
         progressBlock:
         { receivedSize, totalSize in
-          dispatch_async(callbackQueue, {
-            downloadProgressBlock(CGFloat(receivedSize / totalSize))
-          })
+          if downloadProgressBlock != nil {
+            let queue = callbackQueue != nil ?
+              callbackQueue : dispatch_get_main_queue()
+            dispatch_async(queue, {
+              downloadProgressBlock(CGFloat(receivedSize / totalSize))
+            })
+          }
         })
         { image, error, cacheType, imageURL in
-          dispatch_async(callbackQueue, {
-            completion(image!.CGImage, error)
-          })
+          if completion != nil {
+            let queue = callbackQueue != nil ?
+              callbackQueue : dispatch_get_main_queue()
+            dispatch_async(queue, {
+              completion(image!.CGImage, error)
+            })
+          }
       }
+
       return task
   }
 

--- a/Source/Nodes/Defaults/AttachmentGridNode.swift
+++ b/Source/Nodes/Defaults/AttachmentGridNode.swift
@@ -27,6 +27,10 @@ public class AttachmentGridNode: PostComponentNode {
   public var imageNodes = [ASImageNode]()
   public var counterNode: CounterNode?
 
+  // MARK: - Image Cache
+
+  public lazy var downloader = ImageCache()
+
   // MARK: - Initialization
 
   public required init(post: Post, width: CGFloat) {
@@ -42,7 +46,7 @@ public class AttachmentGridNode: PostComponentNode {
     var lastImageSize: CGSize?
 
     for (index, attachment) in attachments.enumerate() {
-      let imageNode = ASNetworkImageNode()
+      let imageNode = ASNetworkImageNode(cache: nil, downloader: downloader)
       imageNode.backgroundColor = .grayColor()
       imageNode.frame.size = sizeForThumbnailAtIndex(index)
       imageNode.URL = attachment.wallModel.thumbnail.url

--- a/Source/Nodes/Defaults/HeaderNode.swift
+++ b/Source/Nodes/Defaults/HeaderNode.swift
@@ -39,7 +39,7 @@ public class HeaderNode: PostComponentNode {
     }()
 
   public lazy var authorAvatarNode: ASNetworkImageNode = { [unowned self] in
-    let node = ASNetworkImageNode(cache: nil, downloader: downloader)
+    let node = ASNetworkImageNode(cache: nil, downloader: self.downloader)
 
     if let author = self.post.author, avatar = author.wallModel.image {
       node.backgroundColor = .grayColor()

--- a/Source/Nodes/Defaults/HeaderNode.swift
+++ b/Source/Nodes/Defaults/HeaderNode.swift
@@ -39,7 +39,7 @@ public class HeaderNode: PostComponentNode {
     }()
 
   public lazy var authorAvatarNode: ASNetworkImageNode = { [unowned self] in
-    let node = ASNetworkImageNode()
+    let node = ASNetworkImageNode(cache: nil, downloader: downloader)
 
     if let author = self.post.author, avatar = author.wallModel.image {
       node.backgroundColor = .grayColor()
@@ -76,6 +76,10 @@ public class HeaderNode: PostComponentNode {
   private var secondRowY: CGFloat {
     return height / 2 + authorVerticalPadding
   }
+
+  // MARK: - Image Cache
+
+  public lazy var downloader = ImageCache()
 
   // MARK: - ConfigurableNode
 

--- a/Wall.podspec
+++ b/Wall.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'AsyncDisplayKit', '~> 1.2'
   s.dependency 'Sugar'
+  s.dependency 'Kingfisher'
 
   s.frameworks = 'Foundation'
 end


### PR DESCRIPTION
I've created a wrapper around Kingfisher to forward ASNetworkImageNode's delegate calls to it. It will improve UI as user won't see "gray squares" so frequently anymore.

